### PR TITLE
Unboxing of Option types

### DIFF
--- a/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -1,5 +1,6 @@
 package io.swagger.scala.converter
 
+import com.fasterxml.jackson.databind.`type`.CollectionLikeType
 import io.swagger.annotations.ApiModelProperty
 
 import io.swagger.converter._
@@ -51,10 +52,23 @@ class SwaggerScalaModelConverter extends ModelConverter {
         }
       }
     }
+
+    // Unbox scala options
+    val nextType = `type` match {
+        case clt: CollectionLikeType if (isOption(cls)) => clt.getContentType
+        case _ => `type`
+      }
+
     if(chain.hasNext())
-      chain.next().resolveProperty(`type`, context, annotations, chain)
+      chain.next().resolveProperty(nextType, context, annotations, chain)
     else
       null
+  }
+
+  private def isOption(cls: Class[_]): Boolean ={
+    val optionClass = classOf[scala.Option[_]]
+
+    cls == optionClass
   }
 
   override

--- a/src/test/scala/ModelPropertyParserTest.scala
+++ b/src/test/scala/ModelPropertyParserTest.scala
@@ -23,4 +23,27 @@ class ModelPropertyParserTest extends FlatSpec with Matchers {
     isFoo should not be (null)
     isFoo.isInstanceOf[BooleanProperty] should be (true)
   }
+
+  it should "process Option[String] as string" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWOptionString]).asScala.toMap
+    val model = schemas.get("ModelWOptionString")
+    model should be ('defined)
+    val stringOpt = model.get.getProperties().get("stringOpt")
+    stringOpt should not be (null)
+    stringOpt.isInstanceOf[StringProperty] should be (true)
+    val stringWithDataType = model.get.getProperties().get("stringWithDataTypeOpt")
+    stringWithDataType should not be (null)
+    stringWithDataType.isInstanceOf[StringProperty] should be (true)
+  }
+
+  it should "process Option[Model] as Model" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWOptionModel]).asScala.toMap
+    val model = schemas.get("ModelWOptionModel")
+    model should be ('defined)
+    val modelOpt = model.get.getProperties().get("modelOpt")
+    modelOpt should not be (null)
+    modelOpt.isInstanceOf[RefProperty] should be (true)
+  }
 }

--- a/src/test/scala/models/ModelWOptionString.scala
+++ b/src/test/scala/models/ModelWOptionString.scala
@@ -1,0 +1,17 @@
+package models
+
+import io.swagger.annotations.{ ApiModel, ApiModelProperty }
+import scala.annotation.meta.field
+
+@ApiModel(description = "An Option[String] is a string not an array")
+case class ModelWOptionString (
+           @(ApiModelProperty @field)(value="this is an Option[String] attribute") stringOpt: Option[String],
+           @(ApiModelProperty @field)(value="this is an Option[String] attribute with a dataType", dataType = "string")
+             stringWithDataTypeOpt: Option[String]
+                                   )
+
+
+@ApiModel(description = "An Option[Model] is not an array")
+case class ModelWOptionModel (
+           @(ApiModelProperty @field)(value="this is an Option[Model] attribute") modelOpt: Option[ModelWOptionString]
+                               )


### PR DESCRIPTION
I was running into an issue where models that have Option[_] properties are being converted to Swagger Spec as array type instead of the boxed type.  

This pull request unboxes an Option in the model converter such that:
Option[String] => type: string
Option[T] => type: $ref
