### PR TITLE
Support scala.math.BigDecimal the same java.math.BigDecimal is supported

### DIFF
--- a/src/test/scala/ModelPropertyParserTest.scala
+++ b/src/test/scala/ModelPropertyParserTest.scala
@@ -1,4 +1,5 @@
 import io.swagger.converter._
+import io.swagger.models.properties
 
 import models._
 
@@ -45,5 +46,16 @@ class ModelPropertyParserTest extends FlatSpec with Matchers {
     val modelOpt = model.get.getProperties().get("modelOpt")
     modelOpt should not be (null)
     modelOpt.isInstanceOf[RefProperty] should be (true)
+  }
+
+  it should "process Model with Scala BigDeciaml as Number" in {
+    case class TestModel(field: BigDecimal)
+
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[TestModel]).asScala.toMap
+    val model = schemas.values.headOption
+    model should be ('defined)
+    val modelOpt = model.get.getProperties().get("field")
+    modelOpt shouldBe a [properties.DecimalProperty]
   }
 }


### PR DESCRIPTION
If scala's BigDecimal is present then swagger json contains such $ref definition:

```
"BigDecimal" : {
      "type" : "object",
      "properties" : {
        "decimalFloat" : {
          "type" : "boolean",
          "default" : false
        },
        "decimalDouble" : {
          "type" : "boolean",
          "default" : false
        },
        "binaryDouble" : {
          "type" : "boolean",
          "default" : false
        },
        "binaryFloat" : {
          "type" : "boolean",
          "default" : false
        },
        "exactDouble" : {
          "type" : "boolean",
          "default" : false
        },
        "exactFloat" : {
          "type" : "boolean",
          "default" : false
        },
        "validByte" : {
          "type" : "boolean",
          "default" : false
        },
        "validChar" : {
          "type" : "boolean",
          "default" : false
        },
        "validInt" : {
          "type" : "boolean",
          "default" : false
        },
        "validShort" : {
          "type" : "boolean",
          "default" : false
        },
        "validLong" : {
          "type" : "boolean",
          "default" : false
        },
        "validFloat" : {
          "type" : "boolean",
          "default" : false
        },
        "whole" : {
          "type" : "boolean",
          "default" : false
        },
        "validDouble" : {
          "type" : "boolean",
          "default" : false
        }
      }
    }
```

with this fix field simply becomes a number `"type" : "number"`
