### PR TITLE
upgrade dependencies and add test case

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ version := "1.0.1-SNAPSHOT"
 
 scalaVersion := "2.10.4"
 
-crossScalaVersions := Seq("2.10.0", "2.10.1", "2.10.2", "2.10.3", "2.10.4", "2.11.0", "2.11.1", "2.11.4")
+crossScalaVersions := Seq("2.10.0", "2.10.1", "2.10.2", "2.10.3", "2.10.4", "2.10.6", "2.11.0", "2.11.1", "2.11.4", "2.11.7")
 
 organizationHomepage in ThisBuild := Some(url("http://swagger.io"))
 
@@ -23,10 +23,10 @@ publishArtifact in Test := false
 pomIncludeRepository := { x => false }
 
 libraryDependencies ++= Seq(
-  "io.swagger" % "swagger-core" % "1.5.5",
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "io.swagger" % "swagger-core" % "1.5.6",
+  "org.scalatest" %% "scalatest" % "2.2.5" % "test",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2",
-  "junit" % "junit" % "4.11" % "test"
+  "junit" % "junit" % "4.12" % "test"
 )
 
 publishTo <<= (version) { version: String =>

--- a/src/test/scala/ModelPropertyParserTest.scala
+++ b/src/test/scala/ModelPropertyParserTest.scala
@@ -33,9 +33,11 @@ class ModelPropertyParserTest extends FlatSpec with Matchers {
     val stringOpt = model.get.getProperties().get("stringOpt")
     stringOpt should not be (null)
     stringOpt.isInstanceOf[StringProperty] should be (true)
+    stringOpt.getRequired should be (false)
     val stringWithDataType = model.get.getProperties().get("stringWithDataTypeOpt")
     stringWithDataType should not be (null)
     stringWithDataType.isInstanceOf[StringProperty] should be (true)
+    stringWithDataType.getRequired should be (false)
   }
 
   it should "process Option[Model] as Model" in {
@@ -48,7 +50,7 @@ class ModelPropertyParserTest extends FlatSpec with Matchers {
     modelOpt.isInstanceOf[RefProperty] should be (true)
   }
 
-  it should "process Model with Scala BigDeciaml as Number" in {
+  it should "process Model with Scala BigDecimal as Number" in {
     case class TestModel(field: BigDecimal)
 
     val converter = ModelConverters.getInstance()

--- a/src/test/scala/ScalaModelTest.scala
+++ b/src/test/scala/ScalaModelTest.scala
@@ -48,10 +48,20 @@ class ScalaModelTest extends FlatSpec with Matchers {
     val friends = model.getProperties().get("friends")
     friends.isInstanceOf[ArrayProperty] should be (true)
   }
+  
+  it should "read a model with vector of ints" in {
+    val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithIntVector]).asScala
+    val model = schemas("ModelWithIntVector")
+    val prop = model.getProperties().get("ints")
+    prop.isInstanceOf[ArrayProperty] should be (true)
+    prop.asInstanceOf[ArrayProperty].getItems.getType should be ("number")
+  }
 }
 
 case class ModelWithVector (
   name: String,
   friends: Vector[String])
+  
+case class ModelWithIntVector (ints: Vector[Int])
 
 case class SimpleUser (id: Long, name: String, @(ApiModelProperty @field)(value = "the birthdate") date: java.util.Date)


### PR DESCRIPTION
Add test case for https://github.com/swagger-api/swagger-scala-module/issues/7.
It appears the latest code does return 'number' as the type for the vector of ints.
