### PR TITLE
Update jackson-module-scala to version 2.7.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ pomIncludeRepository := { x => false }
 libraryDependencies ++= Seq(
   "io.swagger" % "swagger-core" % "1.5.8-SNAPSHOT",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.7.2",
   "junit" % "junit" % "4.12" % "test"
 )
 


### PR DESCRIPTION
jackson-module-scala is a bit behind and in their [README](https://github.com/FasterXML/jackson-module-scala) they suggest not using anything older than 2.6.5 or 2.7.2. This updates the version to 2.7.2.
