### PR TITLE
chore: update jackson-module-scala to 2.8.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ pomIncludeRepository := { x => false }
 libraryDependencies ++= Seq(
   "io.swagger" % "swagger-core" % "1.5.8",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.2",
   "junit" % "junit" % "4.12" % "test"
 )
 

--- a/src/test/scala/ScalaModelTest.scala
+++ b/src/test/scala/ScalaModelTest.scala
@@ -1,19 +1,13 @@
+import io.swagger.annotations.ApiModelProperty
 import io.swagger.converter._
-
-import models._
-import models.OrderSize._
-
-import io.swagger.util.Json
-import io.swagger.annotations.{ ApiModel, ApiModelProperty }
 import io.swagger.models.properties._
-
-import scala.collection.JavaConverters._
-import scala.annotation.meta.field
-
+import models._
 import org.junit.runner.RunWith
+import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+
+import scala.annotation.meta.field
+import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class ScalaModelTest extends FlatSpec with Matchers {
@@ -21,23 +15,34 @@ class ScalaModelTest extends FlatSpec with Matchers {
     val schemas = ModelConverters.getInstance().readAll(classOf[SModelWithEnum]).asScala
     val userSchema = schemas("SModelWithEnum")
 
-    val orderSize = userSchema.getProperties().get("orderSize")
+    val orderSize = userSchema.getProperties.get("orderSize")
     orderSize.isInstanceOf[StringProperty] should be (true)
 
     val sp = orderSize.asInstanceOf[StringProperty]
-    (sp.getEnum().asScala.toSet & Set("TALL", "GRANDE", "VENTI")).size should be (3)
+    (sp.getEnum.asScala.toSet & Set("TALL", "GRANDE", "VENTI")).size should be (3)
+  }
+
+  it should "extract an optional scala enum" in {
+    val schemas = ModelConverters.getInstance().readAll(classOf[SModelWithOptionalEnum]).asScala
+    val userSchema = schemas("SModelWithOptionalEnum")
+
+    val orderSize = userSchema.getProperties.get("orderSize")
+    orderSize.isInstanceOf[StringProperty] should be (true)
+
+    val sp = orderSize.asInstanceOf[StringProperty]
+    (sp.getEnum.asScala.toSet & Set("TALL", "GRANDE", "VENTI")).size should be (3)
   }
 
   it should "read a scala case class with properties" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[SimpleUser]).asScala
     val userSchema = schemas("SimpleUser")
-    val id = userSchema.getProperties().get("id")
+    val id = userSchema.getProperties.get("id")
     id.isInstanceOf[LongProperty] should be (true)
 
-    val name = userSchema.getProperties().get("name")
+    val name = userSchema.getProperties.get("name")
     name.isInstanceOf[StringProperty] should be (true)
 
-    val date = userSchema.getProperties().get("date")
+    val date = userSchema.getProperties.get("date")
     date.isInstanceOf[DateTimeProperty] should be (true)
     date.getDescription should be ("the birthdate")
   }
@@ -45,14 +50,14 @@ class ScalaModelTest extends FlatSpec with Matchers {
   it should "read a model with vector property" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithVector]).asScala
     val model = schemas("ModelWithVector")
-    val friends = model.getProperties().get("friends")
+    val friends = model.getProperties.get("friends")
     friends.isInstanceOf[ArrayProperty] should be (true)
   }
-  
+
   it should "read a model with vector of ints" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithIntVector]).asScala
     val model = schemas("ModelWithIntVector")
-    val prop = model.getProperties().get("ints")
+    val prop = model.getProperties.get("ints")
     prop.isInstanceOf[ArrayProperty] should be (true)
     prop.asInstanceOf[ArrayProperty].getItems.getType should be ("number")
   }

--- a/src/test/scala/models/EnumModels.scala
+++ b/src/test/scala/models/EnumModels.scala
@@ -7,8 +7,13 @@ import scala.annotation.meta.field
 
 @ApiModel(description = "Scala model containing an Enumeration Value that is annotated with the dataType of the Enumeration class")
 case class SModelWithEnum(
-  // @(ApiModelProperty @field)(value = "Textual label") label: Option[String] = None,
-  @(ApiModelProperty @field)(value = "Order Size", dataType = "models.OrderSize$") orderSize: OrderSize = OrderSize.TALL)
+  @(ApiModelProperty @field)(example = "fo", value = "Order Size", dataType = "models.OrderSize$") orderSize: OrderSize = OrderSize.TALL
+)
+
+@ApiModel(description = "Scala model containing an Optional Enumeration Value")
+case class SModelWithOptionalEnum(
+  @(ApiModelProperty @field)(value = "Order Size", dataType = "models.OrderSize$") orderSize: Option[OrderSize] = None
+)
 
 case object OrderSize extends Enumeration(0) {
   type OrderSize = Value


### PR DESCRIPTION
Since jackson-module-scala version `2.7.4`, Scala `Option` type is no longer treated as `CollectionLikeType`, instead `ReferenceType`, as in https://github.com/FasterXML/jackson-module-scala/issues/248

This PR update jackson-module-scala to 2.8.2 and resolve the issue avobe, additionally handling optional type of `Enumeration`

By the way I made a PR to `develop` branch.  Was it correct destination?
