### PR TITLE
Set all properties besides those in option as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Which will include the proper cross-publish version of swagger-scala-module.
 ## How does it work?
 Including the library in your project allows the swagger extension module to discover this module, bringing in the appropriate jackson library in the process.  You can then use scala classes and objects in your swagger project.
 
+## Treatment of `Option` and `required`
+All properties, besides those wrapped in `Option` or explicitly set via annotations `@ApiModelProperty(required = false)`, default to `required = true`  in the generated swagger model. See [#7](https://github.com/swagger-api/swagger-scala-module/issues/7)
+
 ## Support
 The following methods are available to obtain support for Swagger:
 

--- a/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -32,26 +32,33 @@ class SwaggerScalaModelConverter extends ModelConverter {
             val sp = new StringProperty()
             for (v <- enumInstance.values)
               sp._enum(v.toString)
+            sp.setRequired(true)
             return sp
           }
         case None =>
           if (cls.isAssignableFrom(classOf[BigDecimal])) {
-            return PrimitiveType.DECIMAL.createProperty()
+            val dp = PrimitiveType.DECIMAL.createProperty()
+            dp.setRequired(true)
+            return dp
           }
       }
     }
 
     // Unbox scala options
-    val nextType = `type` match {
-        case clt: CollectionLikeType if isOption(cls) => clt.getContentType
-        case _ => `type`
-      }
-
-    if (chain.hasNext())
-      chain.next().resolveProperty(nextType, context, annotations, chain)
-    else
-      null
+    `type` match {
+      case clt: CollectionLikeType if isOption(cls) && chain.hasNext =>
+        val nextType = clt.getContentType
+        val nextResolved = chain.next().resolveProperty(nextType, context, annotations, chain)
+        nextResolved.setRequired(false)
+        nextResolved
+      case t if chain.hasNext =>
+        val nextResolved = chain.next().resolveProperty(t, context, annotations, chain)
+        nextResolved.setRequired(true)
+        nextResolved
+      case _ =>
+        null
     }
+  }
 
   override
   def resolve(`type`: Type, context: ModelConverterContext, chain: Iterator[ModelConverter]): Model = {

--- a/src/test/scala/ModelPropertyParserTest.scala
+++ b/src/test/scala/ModelPropertyParserTest.scala
@@ -1,17 +1,12 @@
 import io.swagger.converter._
 import io.swagger.models.properties
-
-import models._
-
-import io.swagger.util.Json
 import io.swagger.models.properties._
-
-import scala.collection.JavaConverters._
-
+import models._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyParserTest extends FlatSpec with Matchers {
@@ -59,5 +54,28 @@ class ModelPropertyParserTest extends FlatSpec with Matchers {
     model should be ('defined)
     val modelOpt = model.get.getProperties().get("field")
     modelOpt shouldBe a [properties.DecimalProperty]
+    modelOpt.getRequired should be (true)
+  }
+
+  it should "process all properties as required barring Option[_] or if overridden in annotation" in {
+    val schemas = ModelConverters
+      .getInstance()
+      .readAll(classOf[ModelWithOptionAndNonOption])
+      .asScala
+
+    val model = schemas("ModelWithOptionAndNonOption")
+    model should not be (null)
+
+    val optional = model.getProperties().get("optional")
+    optional.getRequired should be (false)
+
+    val required = model.getProperties().get("required")
+    required.getRequired should be (true)
+
+    val forcedRequired = model.getProperties().get("forcedRequired")
+    forcedRequired.getRequired should be (true)
+
+    val forcedOptional = model.getProperties().get("forcedOptional")
+    forcedOptional.getRequired should be (false)
   }
 }

--- a/src/test/scala/models/ModelWOptionString.scala
+++ b/src/test/scala/models/ModelWOptionString.scala
@@ -15,3 +15,10 @@ case class ModelWOptionString (
 case class ModelWOptionModel (
            @(ApiModelProperty @field)(value="this is an Option[Model] attribute") modelOpt: Option[ModelWOptionString]
                                )
+
+case class ModelWithOptionAndNonOption(
+                                        required: String,
+                                        optional: Option[String],
+                                        @ApiModelProperty(required = false) forcedOptional: String,
+                                        @ApiModelProperty(required = true) forcedRequired: Option[String]
+                                      )


### PR DESCRIPTION
Connects to #7

Defaults to all properties being set to required unless wrapped in `Option` or if manually overridden by an annotation.

This change is not implemented in #23 and would need some tweaks if that's merged first.
