### PR TITLE
- adding cross-compilation to 2.12.0, bumped all versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ organization := "io.swagger"
 
 version := "1.0.3-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.0", "2.10.1", "2.10.2", "2.10.3", "2.10.4", "2.10.6", "2.11.0", "2.11.1", "2.11.4", "2.11.7")
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.0")
 
 organizationHomepage in ThisBuild := Some(url("http://swagger.io"))
 
@@ -23,9 +23,9 @@ publishArtifact in Test := false
 pomIncludeRepository := { x => false }
 
 libraryDependencies ++= Seq(
-  "io.swagger" % "swagger-core" % "1.5.8",
-  "org.scalatest" %% "scalatest" % "2.2.5" % "test",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2",
+  "io.swagger" % "swagger-core" % "1.5.10",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4",
   "junit" % "junit" % "4.12" % "test"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.13

--- a/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -4,7 +4,7 @@ import java.lang.annotation.Annotation
 import java.lang.reflect.Type
 import java.util.Iterator
 
-import com.fasterxml.jackson.databind.`type`.CollectionLikeType
+import com.fasterxml.jackson.databind.`type`.ReferenceType
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import io.swagger.converter._
 import io.swagger.models.Model
@@ -43,7 +43,7 @@ class SwaggerScalaModelConverter extends ModelConverter {
 
     // Unbox scala options
     val nextType = `type` match {
-        case clt: CollectionLikeType if isOption(cls) => clt.getContentType
+        case rt: ReferenceType if isOption(cls) => rt.getContentType
         case _ => `type`
       }
 


### PR DESCRIPTION
Wanted to have this module cross compiled to Scala 2.12.0 now that it has reached GA. This PR serves this purpose.

I had to bump a number of dependencies to get this to work and while at it, I took the liberty of dropping explicit cross-compilation to minor/patch scala versions and bumped sbt version too.

Note that minimum 2.10.4 is required anyway if JDK8 is used to compile.