### PR TITLE
Fix deprecation warnings in sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,8 @@ libraryDependencies ++= Seq(
   "junit" % "junit" % "4.12" % "test"
 )
 
-publishTo <<= (version) { version: String =>
-  if (version.trim.endsWith("SNAPSHOT"))
+publishTo := {
+  if (version.value.trim.endsWith("SNAPSHOT"))
     Some("Sonatype Nexus Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
   else
     Some("Sonatype Nexus Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
@@ -65,21 +65,23 @@ startYear := Some(2014)
 
 licenses := Seq(("Apache License 2.0", new URL("http://www.apache.org/licenses/LICENSE-2.0.html")))
 
-pomExtra <<= (pomExtra, name, description) {(pom, name, desc) => pom ++ Group(
-  <scm>
-    <connection>scm:git:git@github.com:swagger-api/swagger-scala-module.git</connection>
-    <developerConnection>scm:git:git@github.com:swagger-api/swagger-scala-module.git</developerConnection>
-    <url>https://github.com/swagger-api/swagger-scala-module</url>
-  </scm>
-  <issueManagement>
-    <system>github</system>
-    <url>https://github.com/swagger-api/swagger-scala-module/issues</url>
-  </issueManagement>
-  <developers>
-    <developer>
-      <id>fehguy</id>
-      <name>Tony Tam</name>
-      <email>fehguy@gmail.com</email>
-    </developer>
-  </developers>
-)}
+pomExtra := {
+  pomExtra.value ++ Group(
+    <scm>
+      <connection>scm:git:git@github.com:swagger-api/swagger-scala-module.git</connection>
+      <developerConnection>scm:git:git@github.com:swagger-api/swagger-scala-module.git</developerConnection>
+      <url>https://github.com/swagger-api/swagger-scala-module</url>
+    </scm>
+      <issueManagement>
+        <system>github</system>
+        <url>https://github.com/swagger-api/swagger-scala-module/issues</url>
+      </issueManagement>
+      <developers>
+        <developer>
+          <id>fehguy</id>
+          <name>Tony Tam</name>
+          <email>fehguy@gmail.com</email>
+        </developer>
+      </developers>
+  )
+}


### PR DESCRIPTION
Fixes deprecation warnings in sbt project by removing `<<=` in favor of `:=`

see http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html 