### PR TITLE
Fix Option[Boolean] being recognized as a BigDecimal

### DIFF
--- a/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -36,11 +36,11 @@ class SwaggerScalaModelConverter extends ModelConverter {
             return sp
           }
         case None =>
-          if (cls.isAssignableFrom(classOf[BigDecimal])) {
+          if (cls == classOf[BigDecimal]) {
             val dp = PrimitiveType.DECIMAL.createProperty()
             dp.setRequired(true)
             return dp
-          } else if (cls.isAssignableFrom(classOf[BigInt])) {
+          } else if (cls == classOf[BigInt]) {
             val dp = PrimitiveType.INT.createProperty()
             dp.setRequired(true)
             return dp

--- a/src/test/scala/ModelPropertyParserTest.scala
+++ b/src/test/scala/ModelPropertyParserTest.scala
@@ -97,6 +97,17 @@ class ModelPropertyParserTest extends FlatSpec with Matchers {
     optBigDecimal.getRequired should be (false)
   }
 
+  it should "process Model with Scala Option Boolean" in {
+    val converter = ModelConverters.getInstance()
+    val schemas = converter.readAll(classOf[ModelWOptionBoolean]).asScala.toMap
+    val model = schemas.get("ModelWOptionBoolean")
+    model should be ('defined)
+    val optBoolean = model.get.getProperties().get("optBoolean")
+    optBoolean should not be (null)
+    optBoolean shouldBe a [properties.ObjectProperty]
+    optBoolean.getRequired should be (false)
+  }
+
   it should "process all properties as required barring Option[_] or if overridden in annotation" in {
     val schemas = ModelConverters
       .getInstance()

--- a/src/test/scala/ScalaModelTest.scala
+++ b/src/test/scala/ScalaModelTest.scala
@@ -48,20 +48,29 @@ class ScalaModelTest extends FlatSpec with Matchers {
     val friends = model.getProperties().get("friends")
     friends.isInstanceOf[ArrayProperty] should be (true)
   }
-  
+
   it should "read a model with vector of ints" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithIntVector]).asScala
     val model = schemas("ModelWithIntVector")
     val prop = model.getProperties().get("ints")
     prop.isInstanceOf[ArrayProperty] should be (true)
-    prop.asInstanceOf[ArrayProperty].getItems.getType should be ("number")
+    prop.asInstanceOf[ArrayProperty].getItems.getType should be ("object")
+  }
+
+  it should "read a model with vector of booleans" in {
+    val schemas = ModelConverters.getInstance().readAll(classOf[ModelWithBooleanVector]).asScala
+    val model = schemas("ModelWithBooleanVector")
+    val prop = model.getProperties().get("bools")
+    prop.isInstanceOf[ArrayProperty] should be (true)
+    prop.asInstanceOf[ArrayProperty].getItems.getType should be ("object")
   }
 }
 
 case class ModelWithVector (
   name: String,
   friends: Vector[String])
-  
+
 case class ModelWithIntVector (ints: Vector[Int])
+case class ModelWithBooleanVector (bools: Vector[Boolean])
 
 case class SimpleUser (id: Long, name: String, @(ApiModelProperty @field)(value = "the birthdate") date: java.util.Date)

--- a/src/test/scala/models/ModelWOptionBoolean.scala
+++ b/src/test/scala/models/ModelWOptionBoolean.scala
@@ -1,0 +1,8 @@
+package models
+
+import io.swagger.annotations.ApiModelProperty
+
+import scala.annotation.meta.field
+
+case class ModelWOptionBoolean(
+           @(ApiModelProperty @field)(value="this is an Option[Boolean] attribute") optBoolean: Option[Boolean])


### PR DESCRIPTION
Or more generally `Option[_]`, `List[_]`, `Vector[_]`, etc. containing some primitive type. Primitives can't be used in generic type arguments on the JVM so Scala erases the type argument. `Option[Boolean]` becomes an `Option[java.lang.Object]` at runtime.

Then swagger-scala-module detects it as a BigDecimal:
```scala
classOf[java.lang.Object].isAssignableFrom(classOf[BigDecimal]) == true
```

This change won't make `Option[Boolean]` detect as a `BooleanProperty`. But at least now a custom model converter can be used to correct the type or throw an error